### PR TITLE
DRAFT! Parse `Intent` from `getIntent()` and provide extra getters

### DIFF
--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -1,10 +1,10 @@
 use android_activity::AndroidApp;
-use android_intent::{with_current_env, Action, Extra, Intent};
+use android_intent::{with_current_env, Action, Extra, IntentBuilder};
 
 #[no_mangle]
 fn android_main(_android_app: AndroidApp) {
     with_current_env(|env| {
-        Intent::new(env, Action::Send)
+        IntentBuilder::new(env, Action::Send)
             .with_type("text/plain")
             .with_extra(Extra::Text, "Hello World!")
             .into_chooser()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,14 +5,37 @@ mod extra;
 pub use extra::Extra;
 
 mod intent;
-pub use intent::Intent;
-use jni::{JNIEnv, JavaVM};
+pub use intent::{Intent, IntentBuilder};
+use jni::{errors::Result, objects::JObject, JNIEnv, JavaVM};
 
 /// Run 'f' with the current [`JNIEnv`] from [`ndk_context`].
 pub fn with_current_env(f: impl FnOnce(&mut JNIEnv<'_>)) {
+    // XXX: Pass AndroidActivity?
     let cx = ndk_context::android_context();
     let vm = unsafe { JavaVM::from_raw(cx.vm().cast()) }.unwrap();
     let mut env = vm.attach_current_thread().unwrap();
 
+    // TODO: Pass current activity?
     f(&mut env);
+}
+
+/// Provides the intent from [`Activity#getIntent()`].
+///
+/// [`Activity#getIntent()`]: https://developer.android.com/reference/android/app/Activity#getIntent()
+pub fn with_current_intent<T>(f: impl FnOnce(Intent<'_, '_>) -> T) -> Result<T> {
+    // XXX: Pass AndroidActivity?
+    // XXX: Support onNewIntent() callback with setIntent()?
+    // https://github.com/rust-mobile/ndk/issues/275
+    let cx = ndk_context::android_context();
+    let vm = unsafe { JavaVM::from_raw(cx.vm().cast()) }?;
+    let mut env = vm.attach_current_thread().unwrap();
+    let activity = unsafe { JObject::from_raw(cx.context() as jni::sys::jobject) };
+
+    let object = env
+        .call_method(activity, "getIntent", "()Landroid/content/Intent;", &[])?
+        .l()?;
+
+    let intent = Intent::from_object(&mut env, object);
+
+    Ok(f(intent))
 }


### PR DESCRIPTION
Depends on #9

Works towards https://github.com/rust-mobile/ndk/issues/275 / https://github.com/rust-mobile/ndk/discussions/380, but doesn't yet fully implement the `onNewIntent()` callback + `setIntent()` yet to _follow up_ on new intents delivered to an **already running** app.

---

Quick draft to see if I could use this crate. While there's exactly zero overlap in the current implementation (this crate only provided setters, whereas I only needed getters), I still think this is the right place to implement (continue implementing...) a JNI-based `Intent` wrapper. No other Rust crate exists for this purpose yet while it's still very useful to have in Rust.

This renames `Intent` to `IntentBuilder` (because of storing a "builder-pattern" `Result` inside) and `Inner` to a publicized `Intent` where a few new getters are implemented. A free `with_current_intent()` function is added to provide a view of an `'env` scoped `Intent` based on `Activity.getIntent()` on `ndk_context::android_context()` (I know, broken design).


### TODO
- [ ] Replace `.unwrap()` with proper result wrappers.
- [ ] Include more getters.
- [ ] Move setters to the `Intent` struct where they return normal `Result`s, which can then be captured in the `IntentBuilder` instead.
- [ ] Clean up commented mess :)