### PR TITLE
Add CI and dependabot configuration, fix broken builds

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: "/.github/workflows/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+on:
+  push:
+  pull_request:
+
+jobs:
+  rust:
+    name: Lint Rust code
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup target add aarch64-linux-android
+      - name: Cargo fmt
+        run: cargo fmt --all -- --check
+      - name: Cargo clippy
+        run: cargo clippy --workspace --all-targets --target aarch64-linux-android -- -D warnings
+      - name: Cargo build-test docs
+        # Must build _for_ the host as --target makes this a no-op
+        run: cargo test --doc
+      - name: Test documentation
+        env:
+          RUSTDOCFLAGS: -Dwarnings
+        run: cargo doc --workspace --target aarch64-linux-android
+
+  rust-msrv:
+    name: Build-test MSRV (1.80) with minimal crate dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - name: Generate minimal-version dependencies
+        run: cargo -Zminimal-versions generate-lockfile
+      - uses: dtolnay/rust-toolchain@1.80.0
+        with:
+          targets: aarch64-linux-android
+      - name: Cargo check
+        run: cargo check --workspace --exclude intent-example --all-targets --target aarch64-linux-android

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,15 @@
+name: Publish
+
+on:
+  push:
+    tags:
+    paths: "/Cargo.toml"
+
+jobs:
+  Publish:
+    if: github.repository_owner == 'Traverse-Research'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Publish
+        run: cargo publish --token ${{ secrets.cratesio_token }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,8 @@ description = "Android intent utilities"
 [dependencies]
 jni = "0.20.0"
 ndk-context = "0.1.1"
+
+[workspace]
+members = [
+  "example"
+]

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate_type=["lib", "cdylib"]
+crate-type = ["cdylib"]
 
 [dependencies]
 android-activity = { version = "0.4.0", features = ["native-activity"] }
-android-intent = { path = "../" }
-jni = { version = "0.20.0" }
+android-intent.path = "../"
+jni = "0.20.0"
 ndk-context = "0.1.1"
 
 [package.metadata.android.sdk]

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -11,6 +11,4 @@ fn android_main(_android_app: AndroidApp) {
             .start_activity()
             .unwrap()
     });
-
-    loop {}
 }

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -71,8 +71,8 @@ impl<'env> Intent<'env> {
     /// use android_intent::{Action, Extra, Intent};
     ///
     /// # android_intent::with_current_env(|env| {
-    /// let intent = Intent::new(env, Action::Send);
-    /// let intent = intent.set_class_name("com.excample", "IntentTarget");
+    /// let intent = Intent::new(env, Action::Send)
+    ///     .set_class_name("com.excample", "IntentTarget");
     /// # })
     /// ```
     pub fn set_class_name(
@@ -100,8 +100,8 @@ impl<'env> Intent<'env> {
     /// use android_intent::{Action, Extra, Intent};
     ///
     /// # android_intent::with_current_env(|env| {
-    /// let intent = Intent::new(env, Action::Send);
-    /// let intent = intent.with_extra(Extra::Text, "Hello World!");
+    /// let intent = Intent::new(env, Action::Send)
+    ///     .with_extra(Extra::Text, "Hello World!");
     /// # })
     /// ```
     pub fn with_extra(self, key: impl AsRef<str>, value: impl AsRef<str>) -> Self {
@@ -125,7 +125,8 @@ impl<'env> Intent<'env> {
     /// use android_intent::{Action, Intent};
     ///
     /// # android_intent::with_current_env(|env| {
-    /// let intent = Intent::new(env, Action::Send).into_chooser();
+    /// let intent = Intent::new(env, Action::Send)
+    ///     .into_chooser();
     /// # })
     /// ```
     pub fn into_chooser(self) -> Self {
@@ -159,8 +160,8 @@ impl<'env> Intent<'env> {
     /// use android_intent::{Action, Intent};
     ///
     /// # android_intent::with_current_env(|env| {
-    /// let intent = Intent::new(env, Action::Send);
-    /// let intent = intent.with_type("text/plain");
+    /// let intent = Intent::new(env, Action::Send)
+    ///     .with_type("text/plain");
     /// # })
     /// ```
     pub fn with_type(self, type_name: impl AsRef<str>) -> Self {

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -1,8 +1,4 @@
-use jni::{
-    errors::Error,
-    objects::{JObject, JString},
-    JNIEnv,
-};
+use jni::{errors::Error, objects::JObject, JNIEnv};
 
 struct Inner<'env> {
     env: JNIEnv<'env>,
@@ -33,8 +29,7 @@ impl<'env> Intent<'env> {
             let action_view =
                 env.get_static_field(intent_class, action.as_ref(), "Ljava/lang/String;")?;
 
-            let intent =
-                env.new_object(intent_class, "(Ljava/lang/String;)V", &[action_view.into()])?;
+            let intent = env.new_object(intent_class, "(Ljava/lang/String;)V", &[action_view])?;
 
             Ok(Inner {
                 env,
@@ -51,7 +46,7 @@ impl<'env> Intent<'env> {
                 uri_class,
                 "parse",
                 "(Ljava/lang/String;)Landroid/net/Uri;",
-                &[JString::from(url_string).into()],
+                &[url_string.into()],
             )?;
 
             let intent_class = env.find_class("android/content/Intent")?;
@@ -61,7 +56,7 @@ impl<'env> Intent<'env> {
             let intent = env.new_object(
                 intent_class,
                 "(Ljava/lang/String;Landroid/net/Uri;)V",
-                &[action_view.into(), uri.into()],
+                &[action_view, uri],
             )?;
 
             Ok(Inner {
@@ -77,10 +72,14 @@ impl<'env> Intent<'env> {
     ///
     /// # android_intent::with_current_env(|env| {
     /// let intent = Intent::new(env, Action::Send);
-    /// intent.set_class_name("com.excample", "IntentTarget")
+    /// let intent = intent.set_class_name("com.excample", "IntentTarget");
     /// # })
     /// ```
-    pub fn set_class_name(self, package_name: impl AsRef<str>, class_name: impl AsRef<str>) -> Self {
+    pub fn set_class_name(
+        self,
+        package_name: impl AsRef<str>,
+        class_name: impl AsRef<str>,
+    ) -> Self {
         self.and_then(|inner| {
             let package_name = inner.env.new_string(package_name)?;
             let class_name = inner.env.new_string(class_name)?;
@@ -102,7 +101,7 @@ impl<'env> Intent<'env> {
     ///
     /// # android_intent::with_current_env(|env| {
     /// let intent = Intent::new(env, Action::Send);
-    /// intent.push_extra(Extra::Text, "Hello World!")
+    /// let intent = intent.with_extra(Extra::Text, "Hello World!");
     /// # })
     /// ```
     pub fn with_extra(self, key: impl AsRef<str>, value: impl AsRef<str>) -> Self {
@@ -121,12 +120,12 @@ impl<'env> Intent<'env> {
         })
     }
 
-    /// Builds a new [`Action::Chooser`] Intent that wraps the given target intent.
+    /// Builds a new [`super::Action::Chooser`] Intent that wraps the given target intent.
     /// ```no_run
     /// use android_intent::{Action, Intent};
     ///
     /// # android_intent::with_current_env(|env| {
-    /// let intent = Intent::new(env, Action::Send).into_chhoser();
+    /// let intent = Intent::new(env, Action::Send).into_chooser();
     /// # })
     /// ```
     pub fn into_chooser(self) -> Self {
@@ -161,7 +160,7 @@ impl<'env> Intent<'env> {
     ///
     /// # android_intent::with_current_env(|env| {
     /// let intent = Intent::new(env, Action::Send);
-    /// intent.set_type("text/plain");
+    /// let intent = intent.with_type("text/plain");
     /// # })
     /// ```
     pub fn with_type(self, type_name: impl AsRef<str>) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,5 +14,5 @@ pub fn with_current_env(f: impl FnOnce(JNIEnv)) {
     let vm = unsafe { JavaVM::from_raw(cx.vm().cast()) }.unwrap();
     let env = vm.attach_current_thread().unwrap();
 
-    f(env.clone());
+    f(*env);
 }


### PR DESCRIPTION
Besides a few minor clippy lints, the documentation for this crate was completely stale and not compiling.  By testing this in CI we ensure users will be able to run the code that we provide to them.

Note that strangely most functions in the "builder pattern" `Intent` are suffixed `with_` (because they _move_ `Intent`) except `set_class_name()` (#2) and `into_chooser(_with_title)()`.  Is this intended or an oversight?
